### PR TITLE
Fix build error on Ubuntu 24.04

### DIFF
--- a/include/CrpLib/RawData.h
+++ b/include/CrpLib/RawData.h
@@ -5,6 +5,7 @@
 
 #include <string>
 #include <fstream>
+#include <cstdint>
 
 namespace CrpLib {
 


### PR DESCRIPTION
On Ubuntu 24.04 I was seeing the following error when running make:
```
In file included from /src/include/CrpLib/Lib.h:7,
                 from /src/include/CrpLib/DataAllocator.cpp:1:
/src/include/CrpLib/RawData.h:13:22: error: 'uint32_t' does not name a type
   13 |         static const uint32_t RAWDATA_MAGIC = 0x57415243;
      |                      ^~~~~~~~
/src/include/CrpLib/RawData.h:1:1: note: 'uint32_t' is defined in header '<cstdint>'; did you forget to '#include <cstdint>'?
  +++ |+#include <cstdint>
    1 | #pragma once
make[2]: *** [CMakeFiles/OpenNFS.dir/build.make:1462: CMakeFiles/OpenNFS.dir/include/CrpLib/DataAllocator.cpp.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:489: CMakeFiles/OpenNFS.dir/all] Error 2
make: *** [Makefile:156: all] Error 2
```

This change fixes this.