### PR TITLE
Fix coloring of cars

### DIFF
--- a/shaders/CarFragmentShader.frag
+++ b/shaders/CarFragmentShader.frag
@@ -32,6 +32,9 @@ uniform bool polyFlagged;
 
 void main(){
     vec4 carTexColor = multiTextured ? texture(textureArray, vec3(UV, texIndex)).rgba : texture(carTextureSampler, UV ).rgba;
+    if(carTexColor.a < 1.0) {
+        carTexColor = carTexColor * vec4(carColour, 1.0 - carTexColor.a);
+    }
     vec4 envTexColor = texture( envMapTextureSampler, envUV ).rgba;
 
     vec3 unitNormal = normalize(surfaceNormal);
@@ -59,5 +62,5 @@ void main(){
     totalDiffuse = max(totalDiffuse, 0.7f); // Min brightness
 
 	// Output color = color of the texture at the specified UV
-	color = vec4(totalDiffuse, 1.0) * (carTexColor * vec4(carColour, 1.0) + envReflectivity*envTexColor) + vec4(totalSpecular, 1.0);
+	color = vec4(totalDiffuse, 1.0) * (carTexColor + envReflectivity*envTexColor) + vec4(totalSpecular, 1.0);
 }

--- a/shaders/CarFragmentShader.frag
+++ b/shaders/CarFragmentShader.frag
@@ -35,7 +35,7 @@ void main(){
     vec4 carTexColor = multiTextured ? texture(textureArray, vec3(UV, texIndex)).rgba : texture(carTextureSampler, UV ).rgba;
     if ((carTexColor.a < 0.8 && carTexColor.a > 0.75)) {
         carTexColor = carTexColor * vec4(carSecondaryColour, 1.0 - carTexColor.a);
-    } else if (carTexColor.a > 0.0 && carTexColor.a < 0.75){
+    } else if (carTexColor.a < 0.75){
         carTexColor = carTexColor * vec4(carColour, 1.0 - carTexColor.a);
     }
     vec4 envTexColor = texture( envMapTextureSampler, envUV ).rgba;

--- a/shaders/CarFragmentShader.frag
+++ b/shaders/CarFragmentShader.frag
@@ -23,6 +23,7 @@ uniform vec4 lightColour[MAX_CAR_CONTRIB_LIGHTS];
 uniform vec3 attenuation[MAX_CAR_CONTRIB_LIGHTS];
 
 uniform vec3 carColour;
+uniform vec3 carSecondaryColour;
 uniform float shineDamper;
 uniform float reflectivity;
 uniform float envReflectivity;
@@ -32,7 +33,9 @@ uniform bool polyFlagged;
 
 void main(){
     vec4 carTexColor = multiTextured ? texture(textureArray, vec3(UV, texIndex)).rgba : texture(carTextureSampler, UV ).rgba;
-    if(carTexColor.a < 1.0) {
+    if ((carTexColor.a < 0.8 && carTexColor.a > 0.75)) {
+        carTexColor = carTexColor * vec4(carSecondaryColour, 1.0 - carTexColor.a);
+    } else if (carTexColor.a > 0.0 && carTexColor.a < 0.75){
         carTexColor = carTexColor * vec4(carColour, 1.0 - carTexColor.a);
     }
     vec4 envTexColor = texture( envMapTextureSampler, envUV ).rgba;


### PR DESCRIPTION
It seems at least Need for Speed 3 uses a system where the parts of the texture that should be colored are transparent to some extend and everything else should remain in the color it is. I made a small change to the shader to make it work like that. I've only tested this with NFS 3. Here are some screenshots:
![Screenshot from 2025-02-11 16-11-44](https://github.com/user-attachments/assets/470128bf-0710-4089-8695-6429ddadc0ff)
![Screenshot from 2025-02-11 16-11-32](https://github.com/user-attachments/assets/81149ee8-cd04-4dcb-82a0-966e82d61165)
