### PR TITLE
Fix narrowing warning

### DIFF
--- a/src/Camera/HermiteCamera.cpp
+++ b/src/Camera/HermiteCamera.cpp
@@ -10,7 +10,7 @@ namespace OpenNFS {
 
     void HermiteCamera::UseSpline(const float elapsedTime) {
         // Ensure we're never sampling the hermite curve outside of points arr size.
-        float const tmod{fmod(elapsedTime, (m_loopTime / 202.5f)) / (m_loopTime / 200.f)};
+        float const tmod{fmodf(elapsedTime, (m_loopTime / 202.5f)) / (m_loopTime / 200.f)};
         position = m_trackCameraRail.GetPointAt(tmod);
 
         // Look towards the position that is a few ms away


### PR DESCRIPTION
Without this the following warning will appear:
```
[ 61%] Building CXX object CMakeFiles/OpenNFS.dir/src/Camera/HermiteCamera.cpp.o
/home/wouter/Personal/OpenNFS/src/Camera/HermiteCamera.cpp: In member function ‘void OpenNFS::HermiteCamera::UseSpline(float)’:
/home/wouter/Personal/OpenNFS/src/Camera/HermiteCamera.cpp:13:67: warning: narrowing conversion of ‘(fmod(((double)((float)elapsedTime)), ((double)((float)((OpenNFS::HermiteCamera*)this)->OpenNFS::HermiteCamera::m_loopTime / 2.025e+2f))) / ((double)((float)((OpenNFS::HermiteCamera*)this)->OpenNFS::HermiteCamera::m_loopTime / 2.0e+2f)))’ from ‘double’ to ‘float’ [-Wnarrowing]
   13 |         float const tmod{fmod(elapsedTime, (m_loopTime / 202.5f)) / (m_loopTime / 200.f)};
```