### PR TITLE
Fix color on cars

### DIFF
--- a/shaders/CarFragmentShader.frag
+++ b/shaders/CarFragmentShader.frag
@@ -22,8 +22,8 @@ uniform sampler2D carTextureSampler;
 uniform vec4 lightColour[MAX_CAR_CONTRIB_LIGHTS];
 uniform vec3 attenuation[MAX_CAR_CONTRIB_LIGHTS];
 
-uniform vec3 carColour;
-uniform vec3 carSecondaryColour;
+uniform vec4 carColour;
+uniform vec4 carSecondaryColour;
 uniform float shineDamper;
 uniform float reflectivity;
 uniform float envReflectivity;
@@ -33,10 +33,23 @@ uniform bool polyFlagged;
 
 void main(){
     vec4 carTexColor = multiTextured ? texture(textureArray, vec3(UV, texIndex)).rgba : texture(carTextureSampler, UV ).rgba;
-    if ((carTexColor.a < 0.8 && carTexColor.a > 0.75)) {
-        carTexColor = carTexColor * vec4(carSecondaryColour, 1.0 - carTexColor.a);
+    if (carTexColor.a < 0.35) {
+        color = vec4(0.0, 0.0, 0.0, 0.0);
+        return;
+    } else if ((carTexColor.a < 0.8 && carTexColor.a > 0.75)) {
+        carTexColor = carTexColor * carSecondaryColour;
+        if (carColour.a > 0.0f) {
+            carTexColor.r = carTexColor.r / carSecondaryColour.a;
+            carTexColor.g = carTexColor.g / carSecondaryColour.a;
+            carTexColor.b = carTexColor.b / carSecondaryColour.a;
+        }
     } else if (carTexColor.a < 0.75){
-        carTexColor = carTexColor * vec4(carColour, 1.0 - carTexColor.a);
+        carTexColor = carTexColor * carColour;
+        if (carColour.a > 0.0f) {
+            carTexColor.r = carTexColor.r / carColour.a;
+            carTexColor.g = carTexColor.g / carColour.a;
+            carTexColor.b = carTexColor.b / carColour.a;
+        }
     }
     vec4 envTexColor = texture( envMapTextureSampler, envUV ).rgba;
 

--- a/src/Physics/Car.cpp
+++ b/src/Physics/Car.cpp
@@ -567,9 +567,12 @@ namespace OpenNFS {
         if (!assetData.metadata.colours.empty()) {
             uint32_t const randomColourIdx{(uint32_t)Utils::RandomFloat(0.f, (float)assetData.metadata.colours.size())};
             vehicleProperties.colour = assetData.metadata.colours[randomColourIdx].colour;
+            vehicleProperties.colourSecondary = assetData.metadata.colours[randomColourIdx].colourSecondary;
         } else {
             vehicleProperties.colour =
-                glm::vec3(Utils::RandomFloat(0.f, 1.f), Utils::RandomFloat(0.f, 1.f), Utils::RandomFloat(0.f, 1.f));
+                glm::vec4(Utils::RandomFloat(0.f, 1.f), Utils::RandomFloat(0.f, 1.f), Utils::RandomFloat(0.f, 1.f), 1.0f);
+            vehicleProperties.colourSecondary =
+                glm::vec4(Utils::RandomFloat(0.f, 1.f), Utils::RandomFloat(0.f, 1.f), Utils::RandomFloat(0.f, 1.f), 0.0f);
         }
 
         // State

--- a/src/Physics/Car.h
+++ b/src/Physics/Car.h
@@ -56,7 +56,8 @@ namespace OpenNFS {
         float rollInfluence; // Shift CoM
 
         // Visual
-        glm::vec3 colour;
+        glm::vec4 colour;
+        glm::vec4 colourSecondary;
     };
 
     struct VehicleState {

--- a/src/Renderer/CarRenderer.cpp
+++ b/src/Renderer/CarRenderer.cpp
@@ -7,7 +7,7 @@ namespace OpenNFS {
         // This shader state doesn't change during a car renderpass
         m_carShader.loadProjectionViewMatrices(camera.projectionMatrix, camera.viewMatrix);
         m_carShader.setPolyFlagged(car->carBodyModel.m_polygon_flags.empty());
-        m_carShader.loadCarColor(glm::vec3(1, 1, 1));
+        m_carShader.loadCarColor(glm::vec4(1.0f, 1.0f, 1.0f, 1.0f));
         m_carShader.loadLights(lights);
         m_carShader.loadEnvironmentMapTexture();
         // Check if we're texturing the car from multiple textures, if we are, let the shader know with a uniform and bind texture array
@@ -43,7 +43,7 @@ namespace OpenNFS {
 
         m_carShader.loadTransformationMatrix(car->carBodyModel.ModelMatrix);
         m_carShader.loadSpecular(car->carBodyModel.specularDamper, car->carBodyModel.specularReflectivity, car->carBodyModel.envReflectivity);
-        m_carShader.loadCarColor(car->vehicleProperties.colour); // The colour should only apply to the car body
+        m_carShader.loadCarColor(car->vehicleProperties.colour, car->vehicleProperties.colourSecondary); // The colour should only apply to the car body
         car->carBodyModel.Render();
 
         m_carShader.unbind();

--- a/src/Shaders/CarShader.cpp
+++ b/src/Shaders/CarShader.cpp
@@ -32,6 +32,7 @@ namespace OpenNFS {
         envMapTextureLocation = getUniformLocation("envMapTextureSampler");
         carTextureLocation = getUniformLocation("carTextureSampler");
         colourLocation = getUniformLocation("carColour");
+        colourSecondaryLocation = getUniformLocation("carSecondaryColour");
 
         for (int i = 0; i < MAX_CAR_CONTRIB_LIGHTS; ++i) {
             lightPositionLocation[i] = getUniformLocation("lightPosition[" + std::to_string(i) + "]");
@@ -107,7 +108,8 @@ namespace OpenNFS {
         }
     }
 
-    void CarShader::loadCarColor(const glm::vec3 color) {
-        loadVec3(colourLocation, color);
+    void CarShader::loadCarColor(const glm::vec4 color, const glm::vec4 color_secondary) {
+        loadVec4(colourLocation, color);
+        loadVec4(colourSecondaryLocation, color_secondary);
     }
 }

--- a/src/Shaders/CarShader.h
+++ b/src/Shaders/CarShader.h
@@ -12,7 +12,7 @@ namespace OpenNFS {
       public:
         explicit CarShader();
 
-        void loadCarColor(glm::vec3 color);
+        void loadCarColor(glm::vec4 color, glm::vec4 color_secondary = {0.0, 0.0, 0.0, 0.0});
 
         void loadCarTexture(GLuint textureID);
         void loadLights(const std::vector<const LibOpenNFS::BaseLight*> &lights);


### PR DESCRIPTION
This add the following:
- Support for secondary color loading
- Use the car color alpha to increase the brightness of a color like in the original game
- Hide low alpha parts of the texture, preventing weird things that should not be there from sticking out of the car

This requires the following pull request to be merged: https://github.com/OpenNFS/LibOpenNFS/pull/3

Here are some examples:

![image](https://github.com/user-attachments/assets/9ad96849-5199-4c9e-b5a0-dcbe216b4e7b)
![image](https://github.com/user-attachments/assets/911f7d9c-8163-4734-9018-d28d94315968)
![image](https://github.com/user-attachments/assets/abfc4a8b-7d94-4d30-9151-e55faecbfe96)
![image](https://github.com/user-attachments/assets/8723ade2-b241-432a-9914-370476712399)
![image](https://github.com/user-attachments/assets/cab437ba-5e97-4a92-ad41-2dee9138fc97)


The Diablo letters are a bit dark still unfortunately, because the algorithm used in the game for making the colors brighter with the alpha is not quite the same.