### PR TITLE
Fix build error because of missing variable

### DIFF
--- a/src/Shaders/CarShader.h
+++ b/src/Shaders/CarShader.h
@@ -36,6 +36,7 @@ namespace OpenNFS {
         GLint envMapTextureLocation;
         GLint carTextureLocation;
         GLint colourLocation;
+        GLint colourSecondaryLocation;
         GLint lightPositionLocation[MAX_CAR_CONTRIB_LIGHTS];
         GLint lightColourLocation[MAX_CAR_CONTRIB_LIGHTS];
         GLint attenuationLocation[MAX_CAR_CONTRIB_LIGHTS];


### PR DESCRIPTION
I accidentally got rid of it while rebasing.