### PR TITLE
Run build on pull requests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,6 @@
 name: Build
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   Linux:


### PR DESCRIPTION
We were still missing this. This should make it a bit easier to make sure a PR builds.