### PR TITLE
Optimize AABB tree updates using velocity-based AABB fattening

### DIFF
--- a/src/Physics/IAABB.h
+++ b/src/Physics/IAABB.h
@@ -1,9 +1,12 @@
 #pragma once
 
+#include <glm/vec3.hpp>
+
 class AABB;
 
 class IAABB {
 public:
     virtual ~IAABB()             = default;
     [[nodiscard]] virtual AABB GetAABB() const = 0;
+    [[nodiscard]] virtual glm::vec3 GetVelocity() const { return glm::vec3(0.0f); }
 };

--- a/src/Scene/Entity.cpp
+++ b/src/Scene/Entity.cpp
@@ -115,6 +115,13 @@ namespace OpenNFS {
         return m_boundingBox;
     }
 
+    glm::vec3 Entity::GetVelocity() const {
+        if (dynamic && rigidBody) {
+            return Utils::bulletToGlm(rigidBody->getLinearVelocity());
+        }
+        return glm::vec3(0.0f);
+    }
+
     glm::vec3 Entity::GetDebugColour() const {
         switch (type) {
         case LibOpenNFS::EntityType::XOBJ:

--- a/src/Scene/Entity.h
+++ b/src/Scene/Entity.h
@@ -19,6 +19,7 @@ namespace OpenNFS {
         ~Entity() override = default;
         void Update(); // Update Entity position based on Physics engine
         AABB GetAABB() const override;
+        glm::vec3 GetVelocity() const override;
         glm::vec3 GetDebugColour() const;
 
         std::unique_ptr<btRigidBody> rigidBody;


### PR DESCRIPTION
Implemented velocity-based AABB updates to reduce the frequency of tree rebalancing.
- Added `GetVelocity()` to `IAABB` interface and `Entity` class.
- Modified `AABBTree` to fatten AABBs by velocity when inserting or updating objects.
- This allows `updateLeaf` to skip updates if the new AABB is contained within the previously computed fattened AABB.