### PR TITLE
Fix memory leaks

### DIFF
--- a/src/Physics/Car.cpp
+++ b/src/Physics/Car.cpp
@@ -33,6 +33,9 @@ namespace OpenNFS {
 
     Car::~Car() {
         // And bullet collision shapes on heap
+        for (size_t i = 0; i < m_collisionShapes.size(); i++) {
+            delete m_collisionShapes[i];
+        }
         m_collisionShapes.clear();
         // And the loaded GL textures
         if (renderInfo.isMultitexturedModel) {

--- a/src/Physics/PhysicsManager.cpp
+++ b/src/Physics/PhysicsManager.cpp
@@ -151,6 +151,11 @@ namespace OpenNFS {
                 m_pDynamicsWorld->removeRigidBody(entity->rigidBody.get());
             }
         }
+        delete m_pDynamicsWorld;
+        delete m_pSolver;
+        delete m_pDispatcher;
+        delete m_pCollisionConfiguration;
+        delete m_pBroadphase;
     }
 
 } // namespace OpenNFS

--- a/src/Physics/PhysicsManager.h
+++ b/src/Physics/PhysicsManager.h
@@ -36,10 +36,10 @@ namespace OpenNFS {
         std::shared_ptr<Track> const &m_track;
         std::vector<std::shared_ptr<Car>> m_activeVehicles;
 
-        btBroadphaseInterface *m_pBroadphase;
-        btDefaultCollisionConfiguration *m_pCollisionConfiguration;
-        btCollisionDispatcher *m_pDispatcher;
-        btSequentialImpulseConstraintSolver *m_pSolver;
-        btDiscreteDynamicsWorld *m_pDynamicsWorld;
+        btBroadphaseInterface *m_pBroadphase = nullptr;
+        btDefaultCollisionConfiguration *m_pCollisionConfiguration = nullptr;
+        btCollisionDispatcher *m_pDispatcher = nullptr;
+        btSequentialImpulseConstraintSolver *m_pSolver = nullptr;
+        btDiscreteDynamicsWorld *m_pDynamicsWorld = nullptr;
     };
 } // namespace OpenNFS

--- a/src/Scene/Entity.cpp
+++ b/src/Scene/Entity.cpp
@@ -53,7 +53,7 @@ namespace OpenNFS {
         }
 
         float const entityMass{trackEntity->dynamic ? 100.f : 0.f};
-        btVector3 localInertia;
+        btVector3 localInertia(0, 0, 0);
 
         if (trackEntity->dynamic) {
             m_collisionShape->calculateLocalInertia(entityMass, localInertia);


### PR DESCRIPTION
This doesn't fix everything, but it is an improvement.

With this we go from this valgrind summary:
```
==559882== HEAP SUMMARY:
==559882==     in use at exit: 14,975,196 bytes in 12,643 blocks
==559882==   total heap usage: 1,074,591 allocs, 1,061,948 frees, 780,291,603 bytes allocated
==559882== 
==559882== LEAK SUMMARY:
==559882==    definitely lost: 21,118 bytes in 3 blocks
==559882==    indirectly lost: 806,293 bytes in 53 blocks
==559882==      possibly lost: 12,726,189 bytes in 3,067 blocks
==559882==    still reachable: 1,421,596 bytes in 9,520 blocks
==559882==         suppressed: 0 bytes in 0 blocks
==559882== Rerun with --leak-check=full to see details of leaked memory
==559882== 
==559882== Use --track-origins=yes to see where uninitialised values come from
==559882== For lists of detected and suppressed errors, rerun with: -s
==559882== ERROR SUMMARY: 267889 errors from 31 contexts (suppressed: 0 from 0)
```

To this one:
```
==647009== HEAP SUMMARY:
==647009==     in use at exit: 6,113,454 bytes in 12,539 blocks
==647009==   total heap usage: 1,092,014 allocs, 1,079,475 frees, 783,051,584 bytes allocated
==647009== 
==647009== LEAK SUMMARY:
==647009==    definitely lost: 0 bytes in 0 blocks
==647009==    indirectly lost: 0 bytes in 0 blocks
==647009==      possibly lost: 4,691,858 bytes in 3,019 blocks
==647009==    still reachable: 1,421,596 bytes in 9,520 blocks
==647009==         suppressed: 0 bytes in 0 blocks
==647009== Rerun with --leak-check=full to see details of leaked memory
==647009== 
==647009== Use --track-origins=yes to see where uninitialised values come from
==647009== For lists of detected and suppressed errors, rerun with: -s
==647009== ERROR SUMMARY: 504494 errors from 24 contexts (suppressed: 0 from 0)
```

Error count doesn't say much, but the amount of memory we are losing is much smaller.