### PR TITLE
Improve tree transparancy

### DIFF
--- a/shaders/TrackShader.frag
+++ b/shaders/TrackShader.frag
@@ -117,6 +117,10 @@ void main(){
         discard;
     }
 
+    if (texColour.a < 0.7) {
+        discard;
+    }
+
     if (useClassic){
         color = nfsColor;
     } else {


### PR DESCRIPTION
Before:
<img width="2005" height="407" alt="Screenshot From 2026-01-23 17-38-34" src="https://github.com/user-attachments/assets/90659dc2-6557-4ed8-b125-f010375b541c" />

After:
<img width="2005" height="407" alt="Screenshot From 2026-01-23 17-38-19" src="https://github.com/user-attachments/assets/5f28416c-1e3d-4c2c-8afb-1d0ebce14097" />

I had to set it to 0.7 to see a difference.