### PR TITLE
Fix non-ascii characters causing a crash

### DIFF
--- a/src/Renderer/UIRenderer.cpp
+++ b/src/Renderer/UIRenderer.cpp
@@ -121,8 +121,22 @@ namespace OpenNFS {
 
         glBindVertexArray(atlas.GetVAO());
         // Iterate through all characters
-        for (auto c{text.begin()}; c != text.end(); ++c) {
-            auto const ch_idx = static_cast<unsigned char>(*c);
+        for (int i = 0; i < text.length(); ++i) {
+            // Calculate the code point and put it into a uint8_t
+            uint8_t ch_idx = 0;
+            if (text[i] >> 7 == 0) {
+                // The value is just ascii
+                ch_idx = text[i];
+            } else if ((text[i] >> 2 & 0b111111) == 0b110000) {
+                // The value is a 2 byte utf-8 that is not too big to fit in a uint8_t
+                ch_idx = ((text[i] & 0b11) << 6);
+                ch_idx += (text[i+1] & 0b111111);
+                i++;
+            } else {
+                // Don't try to render code points that don't fit in a uint8_t, we don't have them in the character map
+                continue;
+            }
+
             auto const &ch = atlas.GetCharacter(ch_idx);
 
             // Skip glyphs with no pixels

--- a/src/UI/UIFontAtlas.h
+++ b/src/UI/UIFontAtlas.h
@@ -47,7 +47,7 @@ namespace OpenNFS {
         GLuint m_fontAtlasTexture = 0;
         unsigned int m_atlasWidth = 0;
         unsigned int m_atlasHeight = 0;
-        std::array<CharacterInfo, 128> m_characters{};
+        std::array<CharacterInfo, 256> m_characters{};
         constexpr static uint32_t MAX_WIDTH = 1024;
     };
 } // namespace OpenNFS


### PR DESCRIPTION
This makes a couple of changes:
- Increase the size of the character atlas to include the utf-8 characters with the code points 160 until 255 as well. These are mostly characters needed for different European languages like Spanish, French, Swedish, German and things like the registered trademark and copyright marks.
- Convert 2 byte utf-8 characters that could fit in a uint8_t into a single byte when rendering text.
- Skip over characters we cannot render instead of crashing when rendering text.

To test this just ad some characters which can now be rendered like `ñ`, `ÿ` or `þ` and some characters which cannot be rendered like `馬` or `Ā` to the text of one of the buttons in the menu. There should be no crash and characters that have now been added to the character atlas will be displayed.