### PR TITLE
Fix loading traffic cars

### DIFF
--- a/src/Loaders/CarLoader.cpp
+++ b/src/Loaders/CarLoader.cpp
@@ -54,6 +54,6 @@ namespace OpenNFS {
         if (auto &carAssetName{carAsset.metadata.name}; carAssetName.empty()) {
             carAssetName = carName;
         }
-        return std::make_shared<Car>(carAsset);
+        return std::make_shared<Car>(carAsset, carName);
     }
 } // namespace OpenNFS

--- a/src/Physics/Car.cpp
+++ b/src/Physics/Car.cpp
@@ -10,12 +10,12 @@ namespace OpenNFS {
     constexpr float kCastDistances[kNumRangefinders] = {1.f, 1.f, 1.f, 1.f, 1.f,  1.5f, 2.f, 3.f, 5.f, 5.f,
                                                         5.f, 3.f, 2.f, 2.f, 1.5f, 1.f,  1.f, 1.f, 1.f};
 
-    Car::Car(LibOpenNFS::Car const &carData, GLuint const textureArrayID) : Car(carData) {
+    Car::Car(LibOpenNFS::Car const &carData, GLuint const textureArrayID, std::string const &_assetPath) : Car(carData, _assetPath) {
         renderInfo.textureArrayID = textureArrayID;
         renderInfo.isMultitexturedModel = true;
     }
 
-    Car::Car(LibOpenNFS::Car carData) : assetData(std::move(carData)) {
+    Car::Car(LibOpenNFS::Car carData, std::string const &_assetPath) : assetData(std::move(carData)), assetPath(_assetPath) {
         // Load in vehicle texture data to OpenGL
         if (!Config::get().vulkanRender) {
             this->_LoadTextures();
@@ -298,7 +298,7 @@ namespace OpenNFS {
     void Car::_LoadTextures() {
         std::stringstream carTexturePath;
         int width, height;
-        carTexturePath << CAR_PATH << magic_enum::enum_name(assetData.tag) << "/" << assetData.id;
+        carTexturePath << CAR_PATH << magic_enum::enum_name(assetData.tag) << "/" << assetPath;
 
         if (assetData.tag == NFSVersion::NFS_3 || assetData.tag == NFSVersion::NFS_4) {
             carTexturePath << "/car00.tga";
@@ -307,7 +307,7 @@ namespace OpenNFS {
         } else if (assetData.tag == NFSVersion::MCO) {
             std::stringstream car_alpha_texture_path;
             carTexturePath << "/Textures/0000.BMP";
-            car_alpha_texture_path << CAR_PATH << magic_enum::enum_name(assetData.tag) << "/" << assetData.id << "/Textures/0000-a.BMP";
+            car_alpha_texture_path << CAR_PATH << magic_enum::enum_name(assetData.tag) << "/" << assetPath << "/Textures/0000-a.BMP";
             std::vector<uint8_t> imageData;
             if (ImageLoader::LoadBmpWithAlpha(carTexturePath.str().c_str(), car_alpha_texture_path.str().c_str(), imageData, &width,
                                               &height)) {

--- a/src/Physics/Car.h
+++ b/src/Physics/Car.h
@@ -79,8 +79,8 @@ namespace OpenNFS {
 
     class Car {
       public:
-        explicit Car(LibOpenNFS::Car car);
-        Car(LibOpenNFS::Car const &car, GLuint textureArrayID); // Multitextured car
+        explicit Car(LibOpenNFS::Car car, std::string const &_assetPath);
+        Car(LibOpenNFS::Car const &car, GLuint textureArrayID, std::string const &_assetPath); // Multitextured car
         ~Car();
         void Update(btDynamicsWorld const *dynamicsWorld, float dt);
         void UpdateMeshesToTransform(btTransform const &trans, bool avoidPhysics = false);
@@ -114,6 +114,7 @@ namespace OpenNFS {
         }
 
         LibOpenNFS::Car assetData;
+        std::string assetPath;
 
         // Car configuration data
         VehicleState vehicleState{};

--- a/src/Race/Agents/RacerAgent.cpp
+++ b/src/Race/Agents/RacerAgent.cpp
@@ -7,7 +7,7 @@ namespace OpenNFS {
     RacerAgent::RacerAgent(RacerData const &racerData, std::shared_ptr<Car> const &car, std::shared_ptr<Track> const &raceTrack)
         : CarAgent(AgentType::AI, car, raceTrack) {
         name = racerData.name;
-        this->vehicle = std::make_shared<Car>(car->assetData);
+        this->vehicle = std::make_shared<Car>(car->assetData, car->assetPath);
         // Force original Bullet physics for AI we've tweaked for the new model
         vehicle->physicsModel = PhysicsModel::BULLET;
 


### PR DESCRIPTION
It was only storing the id, but not the actual path where the textures would be. The traffic cars don't look good yet, but they can at least be displayed without a crash like this.