### PR TITLE
Add full utf-8 support and support for adding specific character ranges

### DIFF
--- a/src/UI/UIFontAtlas.cpp
+++ b/src/UI/UIFontAtlas.cpp
@@ -66,34 +66,21 @@ namespace OpenNFS {
         m_atlasWidth = 0;
         m_atlasHeight = 0;
 
-        for (int i = 32; i < 128; i++) {
-            if (FT_Load_Char(face, i, FT_LOAD_RENDER)) {
-                LOG(WARNING) << "FREETYPE: Failed to load character " << static_cast<char>(i);
-                return false;
+        for(CharacterRange range : m_characterRanges) {
+            for (int i = range.start; i < range.end + 1; i++) {
+                if (FT_Load_Char(face, i, FT_LOAD_RENDER)) {
+                    LOG(WARNING) << "FREETYPE: Failed to load character " << static_cast<char>(i);
+                    return false;
+                }
+                if (row_w + g->bitmap.width + 1 >= MAX_WIDTH) {
+                    m_atlasWidth = std::max(m_atlasWidth, row_w);
+                    m_atlasHeight += row_h;
+                    row_w = 0;
+                    row_h = 0;
+                }
+                row_w += g->bitmap.width + 1;
+                row_h = std::max(row_h, g->bitmap.rows);
             }
-            if (row_w + g->bitmap.width + 1 >= MAX_WIDTH) {
-                m_atlasWidth = std::max(m_atlasWidth, row_w);
-                m_atlasHeight += row_h;
-                row_w = 0;
-                row_h = 0;
-            }
-            row_w += g->bitmap.width + 1;
-            row_h = std::max(row_h, g->bitmap.rows);
-        }
-
-        for (int i = 160; i < 256; i++) {
-            if (FT_Load_Char(face, i, FT_LOAD_RENDER)) {
-                LOG(WARNING) << "FREETYPE: Failed to load character " << static_cast<char>(i);
-                return false;
-            }
-            if (row_w + g->bitmap.width + 1 >= MAX_WIDTH) {
-                m_atlasWidth = std::max(m_atlasWidth, row_w);
-                m_atlasHeight += row_h;
-                row_w = 0;
-                row_h = 0;
-            }
-            row_w += g->bitmap.width + 1;
-            row_h = std::max(row_h, g->bitmap.rows);
         }
 
         m_atlasWidth = std::max(m_atlasWidth, row_w);
@@ -117,58 +104,33 @@ namespace OpenNFS {
         int oy = 0;
         row_h = 0;
 
-        for (int i = 32; i < 128; i++) {
-            if (FT_Load_Char(face, i, FT_LOAD_RENDER)) {
-                LOG(WARNING) << "FREETYPE: Failed to load character " << static_cast<char>(i);
-                return false;
+        for(CharacterRange range : m_characterRanges) {
+            for (uint32_t i = range.start; i < range.end + 1; i++) {
+                if (FT_Load_Char(face, i, FT_LOAD_RENDER)) {
+                    LOG(WARNING) << "FREETYPE: Failed to load character " << static_cast<char>(i);
+                    return false;
+                }
+
+                if (ox + g->bitmap.width + 1 >= MAX_WIDTH) {
+                    oy += row_h;
+                    row_h = 0;
+                    ox = 0;
+                }
+
+                glTexSubImage2D(GL_TEXTURE_2D, 0, ox, oy, g->bitmap.width, g->bitmap.rows, GL_RED, GL_UNSIGNED_BYTE, g->bitmap.buffer);
+
+                m_characters[i].ax = g->advance.x >> 6;
+                m_characters[i].ay = g->advance.y >> 6;
+                m_characters[i].bw = g->bitmap.width;
+                m_characters[i].bh = g->bitmap.rows;
+                m_characters[i].bl = g->bitmap_left;
+                m_characters[i].bt = g->bitmap_top;
+                m_characters[i].tx = ox / static_cast<float>(m_atlasWidth);
+                m_characters[i].ty = oy / static_cast<float>(m_atlasHeight);
+
+                row_h = std::max(row_h, g->bitmap.rows);
+                ox += g->bitmap.width + 1;
             }
-
-            if (ox + g->bitmap.width + 1 >= MAX_WIDTH) {
-                oy += row_h;
-                row_h = 0;
-                ox = 0;
-            }
-
-            glTexSubImage2D(GL_TEXTURE_2D, 0, ox, oy, g->bitmap.width, g->bitmap.rows, GL_RED, GL_UNSIGNED_BYTE, g->bitmap.buffer);
-
-            m_characters[i].ax = g->advance.x >> 6;
-            m_characters[i].ay = g->advance.y >> 6;
-            m_characters[i].bw = g->bitmap.width;
-            m_characters[i].bh = g->bitmap.rows;
-            m_characters[i].bl = g->bitmap_left;
-            m_characters[i].bt = g->bitmap_top;
-            m_characters[i].tx = ox / static_cast<float>(m_atlasWidth);
-            m_characters[i].ty = oy / static_cast<float>(m_atlasHeight);
-
-            row_h = std::max(row_h, g->bitmap.rows);
-            ox += g->bitmap.width + 1;
-        }
-
-        for (int i = 160; i < 256; i++) {
-            if (FT_Load_Char(face, i, FT_LOAD_RENDER)) {
-                LOG(WARNING) << "FREETYPE: Failed to load character " << static_cast<char>(i);
-                return false;
-            }
-
-            if (ox + g->bitmap.width + 1 >= MAX_WIDTH) {
-                oy += row_h;
-                row_h = 0;
-                ox = 0;
-            }
-
-            glTexSubImage2D(GL_TEXTURE_2D, 0, ox, oy, g->bitmap.width, g->bitmap.rows, GL_RED, GL_UNSIGNED_BYTE, g->bitmap.buffer);
-
-            m_characters[i].ax = g->advance.x >> 6;
-            m_characters[i].ay = g->advance.y >> 6;
-            m_characters[i].bw = g->bitmap.width;
-            m_characters[i].bh = g->bitmap.rows;
-            m_characters[i].bl = g->bitmap_left;
-            m_characters[i].bt = g->bitmap_top;
-            m_characters[i].tx = ox / static_cast<float>(m_atlasWidth);
-            m_characters[i].ty = oy / static_cast<float>(m_atlasHeight);
-
-            row_h = std::max(row_h, g->bitmap.rows);
-            ox += g->bitmap.width + 1;
         }
 
         glBindTexture(GL_TEXTURE_2D, 0);
@@ -209,7 +171,9 @@ namespace OpenNFS {
         return m_fontQuadVBO;
     }
 
-    UIFontAtlas::CharacterInfo UIFontAtlas::GetCharacter(uint8_t const charIdx) const {
-        return m_characters.at(charIdx);
+    UIFontAtlas::CharacterInfo UIFontAtlas::GetCharacter(uint32_t const charIdx) const {
+        if (m_characters.contains(charIdx))
+            return m_characters.at(charIdx);
+        return m_characters.at('?');
     }
 } // namespace OpenNFS

--- a/src/UI/UIFontAtlas.h
+++ b/src/UI/UIFontAtlas.h
@@ -2,7 +2,8 @@
 
 #include "GL/glew.h"
 
-#include <array>
+#include <unordered_map>
+#include <vector>
 #include <string>
 #include <ft2build.h>
 #include <string>
@@ -20,6 +21,10 @@ namespace OpenNFS {
             float bt; // bitmap_top;
             float tx; // x offset of glyph in texture coordinates
             float ty; // y offset of glyph in texture coordinates
+        };
+        struct CharacterRange {
+            uint32_t start;
+            uint32_t end;
         };
 
         explicit UIFontAtlas() = default;
@@ -40,14 +45,19 @@ namespace OpenNFS {
         uint32_t GetHeight() const;
         GLuint GetVAO() const;
         GLuint GetVBO() const;
-        CharacterInfo GetCharacter(uint8_t charIdx) const;
+        CharacterInfo GetCharacter(uint32_t charIdx) const;
 
       private:
         GLuint m_fontQuadVAO = 0, m_fontQuadVBO = 0;
         GLuint m_fontAtlasTexture = 0;
         unsigned int m_atlasWidth = 0;
         unsigned int m_atlasHeight = 0;
-        std::array<CharacterInfo, 256> m_characters{};
+        std::unordered_map<uint32_t, CharacterInfo> m_characters{};
         constexpr static uint32_t MAX_WIDTH = 1024;
+
+        std::vector<struct CharacterRange> const m_characterRanges{
+          {32, 127},  // ASCII
+          {160, 255},  // Latin-1 suppliments
+        };
     };
 } // namespace OpenNFS


### PR DESCRIPTION
This can eventually enable full support for Japanese. For this the character ranges of the characters that we want to display would need to be added to `m_characterRanges` in `src/UI/UIFontAtlas.h` and the font would have to be replaced with a font that has those characters. Nothing more is needed. With these changes there is no limit to how many characters we could have and the full utf-8 range can be decoded.