### PR TITLE
Pick car colours in the menu

### DIFF
--- a/resources/ui/menu/layout/vehicleSelection.json
+++ b/resources/ui/menu/layout/vehicleSelection.json
@@ -42,6 +42,27 @@
       "onClick": "onVehicleSelectionChange"
     },
     {
+      "id": "vehicleColourSelectionDropdown",
+      "type": "dropdown",
+      "resource": "dropdownButton",
+      "entryResource": "dropdownEntry",
+      "colour": "#568be4",
+      "hoverColour": "#ffff00",
+      "scale": 1.0,
+      "layer": 1,
+      "position": {
+        "x": "30",
+        "y": "900"
+      },
+      "textOffset": {
+        "x": "40",
+        "y": "15"
+      },
+      "font": "Roboto",
+      "onClick": "onVehicleColourSelectionChange",
+      "visible": false
+    },
+    {
       "type": "button",
       "text": "Go!",
       "resource": "pillButton",
@@ -51,7 +72,7 @@
       "layer": 2,
       "position": {
         "x": "30",
-        "y": "900"
+        "y": "750"
       },
       "textOffset": {
         "x": "40",

--- a/src/Config.h
+++ b/src/Config.h
@@ -138,7 +138,7 @@ namespace OpenNFS {
         std::string car;
         NFSVersion trackTag;
         std::string track;
-        size_t colour = -1;
+        int colour = -1;
 
         [[nodiscard]] std::string to_string() const {
             return std::format("CAR= [{}] {} TRACK= [{}] {}", magic_enum::enum_name(carTag), car, magic_enum::enum_name(trackTag), track);

--- a/src/Config.h
+++ b/src/Config.h
@@ -138,6 +138,7 @@ namespace OpenNFS {
         std::string car;
         NFSVersion trackTag;
         std::string track;
+        size_t colour;
 
         [[nodiscard]] std::string to_string() const {
             return std::format("CAR= [{}] {} TRACK= [{}] {}", magic_enum::enum_name(carTag), car, magic_enum::enum_name(trackTag), track);

--- a/src/Config.h
+++ b/src/Config.h
@@ -138,7 +138,7 @@ namespace OpenNFS {
         std::string car;
         NFSVersion trackTag;
         std::string track;
-        size_t colour;
+        size_t colour = -1;
 
         [[nodiscard]] std::string to_string() const {
             return std::format("CAR= [{}] {} TRACK= [{}] {}", magic_enum::enum_name(carTag), car, magic_enum::enum_name(trackTag), track);

--- a/src/GameState/RaceState.cpp
+++ b/src/GameState/RaceState.cpp
@@ -12,6 +12,12 @@ namespace OpenNFS {
         m_currentTrack = TrackLoader::Load(m_context.loadedAssets.trackTag, m_context.loadedAssets.track);
         m_currentCar = CarLoader::LoadCar(m_context.loadedAssets.carTag, m_context.loadedAssets.car);
 
+        // Set the car colour
+        if (m_context.loadedAssets.colour != -1 && m_context.loadedAssets.colour < m_currentCar->assetData.metadata.colours.size()) {
+            m_currentCar->vehicleState.colour = m_currentCar->assetData.metadata.colours[m_context.loadedAssets.colour].colour;
+            m_currentCar->vehicleState.colourSecondary = m_currentCar->assetData.metadata.colours[m_context.loadedAssets.colour].colourSecondary;
+        }
+
         // Create race session
         m_raceSession = std::make_unique<RaceSession>(m_context.window, m_context.logger, m_context.installedNFS, m_currentTrack,
                                                       m_currentCar, m_context.loadedAssets);

--- a/src/GameState/VehicleSelectionState.cpp
+++ b/src/GameState/VehicleSelectionState.cpp
@@ -101,6 +101,7 @@ namespace OpenNFS {
             m_colourSelectionDropdown->isVisible = true;
 
         } else {
+            m_context.loadedAssets.colour = -1;
             m_colourSelectionDropdown->isVisible = false;
         }
         carSelected = true;
@@ -113,6 +114,7 @@ namespace OpenNFS {
         }
         m_currentCar->vehicleState.colour = m_currentCar->assetData.metadata.colours[selection].colour;
         m_currentCar->vehicleState.colourSecondary = m_currentCar->assetData.metadata.colours[selection].colourSecondary;
+        m_context.loadedAssets.colour = selection;
     }
 
     void VehicleSelectionState::OnGo() {

--- a/src/GameState/VehicleSelectionState.cpp
+++ b/src/GameState/VehicleSelectionState.cpp
@@ -77,7 +77,7 @@ namespace OpenNFS {
         return m_nextState;
     }
     void VehicleSelectionState::LoadCar() {
-        size_t selection = m_carSelectionDropdown->GetSelectedEntryIndex();
+        int selection = m_carSelectionDropdown->GetSelectedEntryIndex();
         if (selection == -1) {
             return;
         }
@@ -90,7 +90,7 @@ namespace OpenNFS {
         // Set car colours
         if (!m_currentCar->assetData.metadata.colours.empty()) {
             m_colourSelectionDropdown->entries.clear();
-            for (size_t i = 0; i< m_currentCar->assetData.metadata.colours.size(); i++) {
+            for (int i = 0; i < (int) m_currentCar->assetData.metadata.colours.size(); i++) {
                 m_colourSelectionDropdown->AddEntry(m_cars[selection]->colorNames[i]);
                 if (m_currentCar->assetData.metadata.colours[i].colour == m_currentCar->vehicleState.colour) {
                     m_colourSelectionDropdown->selectedEntry = i;
@@ -108,7 +108,7 @@ namespace OpenNFS {
     }
 
     void VehicleSelectionState::ChangeColour() {
-        size_t selection = m_colourSelectionDropdown->GetSelectedEntryIndex();
+        int selection = m_colourSelectionDropdown->GetSelectedEntryIndex();
         if (selection == -1) {
             return;
         }

--- a/src/GameState/VehicleSelectionState.cpp
+++ b/src/GameState/VehicleSelectionState.cpp
@@ -35,9 +35,10 @@ namespace OpenNFS {
         std::sort(m_cars.begin(), m_cars.end(), compareFunc);
 
         // Load car list into dropdown
-        m_dropdown = std::dynamic_pointer_cast<UIDropdown>(m_uiManager.get()->GetElementWithID("vehicleSelectionDropdown"));
+        m_carSelectionDropdown = std::dynamic_pointer_cast<UIDropdown>(m_uiManager.get()->GetElementWithID("vehicleSelectionDropdown"));
+        m_colourSelectionDropdown = std::dynamic_pointer_cast<UIDropdown>(m_uiManager.get()->GetElementWithID("vehicleColourSelectionDropdown"));
         for (auto car : m_cars) {
-            m_dropdown->AddEntry(car->carName);
+            m_carSelectionDropdown->AddEntry(car->carName);
         }
 
         // Reset next state
@@ -75,7 +76,7 @@ namespace OpenNFS {
         return m_nextState;
     }
     void VehicleSelectionState::LoadCar() {
-        size_t selection = m_dropdown->GetSelectedEntryIndex();
+        size_t selection = m_carSelectionDropdown->GetSelectedEntryIndex();
         if (selection == -1) {
             return;
         }
@@ -84,6 +85,23 @@ namespace OpenNFS {
 
         // Create vehicle selection view
         m_vehicleSelection = std::make_unique<VehicleSelection>(m_context.window, m_context.installedNFS, m_currentCar);
+
+        // Set car colours
+        if (!m_currentCar->assetData.metadata.colours.empty()) {
+            m_colourSelectionDropdown->entries.clear();
+            for (size_t i = 0; i< m_currentCar->assetData.metadata.colours.size(); i++) {
+                m_colourSelectionDropdown->AddEntry(m_cars[selection]->colorNames[i]);
+                if (m_currentCar->assetData.metadata.colours[i].colour == m_currentCar->vehicleState.colour) {
+                    m_colourSelectionDropdown->selectedEntry = i;
+                    m_colourSelectionDropdown->text = m_cars[selection]->colorNames[i];
+                    m_context.loadedAssets.colour = i;
+                }
+            }
+            m_colourSelectionDropdown->isVisible = true;
+
+        } else {
+            m_colourSelectionDropdown->isVisible = false;
+        }
         carSelected = true;
     }
 

--- a/src/GameState/VehicleSelectionState.cpp
+++ b/src/GameState/VehicleSelectionState.cpp
@@ -12,6 +12,7 @@ namespace OpenNFS {
         callbacks["onBack"] = [this]() { m_nextState = GameState::MainMenu; };
         callbacks["onGo"] = [this]() { OnGo(); };
         callbacks["onVehicleSelectionChange"] = [this]() { LoadCar(); };
+        callbacks["onVehicleColourSelectionChange"] = [this]() { ChangeColour(); };
 
         // Create UI manager with vehicle selection layout
         m_uiManager = std::make_unique<UIManager>("../resources/ui/menu/layout/vehicleSelection.json", callbacks);
@@ -103,6 +104,15 @@ namespace OpenNFS {
             m_colourSelectionDropdown->isVisible = false;
         }
         carSelected = true;
+    }
+
+    void VehicleSelectionState::ChangeColour() {
+        size_t selection = m_colourSelectionDropdown->GetSelectedEntryIndex();
+        if (selection == -1) {
+            return;
+        }
+        m_currentCar->vehicleState.colour = m_currentCar->assetData.metadata.colours[selection].colour;
+        m_currentCar->vehicleState.colourSecondary = m_currentCar->assetData.metadata.colours[selection].colourSecondary;
     }
 
     void VehicleSelectionState::OnGo() {

--- a/src/GameState/VehicleSelectionState.h
+++ b/src/GameState/VehicleSelectionState.h
@@ -20,7 +20,7 @@ namespace OpenNFS {
         GameState GetNextState() const override;
 
         void LoadCar();
-
+        void ChangeColour();
         void OnGo();
 
       private:

--- a/src/GameState/VehicleSelectionState.h
+++ b/src/GameState/VehicleSelectionState.h
@@ -33,6 +33,7 @@ namespace OpenNFS {
         std::vector<std::shared_ptr<CarMenuData>> m_cars;
         bool carSelected = false;
 
-        std::shared_ptr<UIDropdown> m_dropdown = nullptr;
+        std::shared_ptr<UIDropdown> m_carSelectionDropdown = nullptr;
+        std::shared_ptr<UIDropdown> m_colourSelectionDropdown = nullptr;
     };
 } // namespace OpenNFS

--- a/src/Renderer/Renderer.cpp
+++ b/src/Renderer/Renderer.cpp
@@ -387,6 +387,7 @@ namespace OpenNFS {
                             if (ImGui::MenuItem(car.c_str())) {
                                 loadedAssets.carTag = installedNFS.tag;
                                 loadedAssets.car = car;
+                                loadedAssets.colour = -1;
                                 assetChange = true;
                             }
                         }

--- a/src/Renderer/UIRenderer.cpp
+++ b/src/Renderer/UIRenderer.cpp
@@ -76,6 +76,8 @@ namespace OpenNFS {
     }
 
     void UIRenderer::RenderDropdown(UIDropdown const *dropdown) const {
+        if (!dropdown->isVisible)
+            return;
         if (dropdown->isOpened) {
             for (size_t i = 0; i < dropdown->entries.size(); i++)
             {

--- a/src/UI/UIDropdown.cpp
+++ b/src/UI/UIDropdown.cpp
@@ -3,9 +3,9 @@
 namespace OpenNFS {
     UIDropdown::UIDropdown(UIResource const &_resource, UIResource const &_entryResource, std::string const &_text, glm::vec4 const &_textColour, glm::vec4 const &_hoverColour,
                        float const _scale, uint32_t const _layer, glm::vec2 const &_location, glm::vec2 const &_textOffset, std::vector<std::string> _entries, std::string _id,
-                       std::string const &_fontName)
+                       std::string const &_fontName, bool const visible)
         : UIElement(UIElementType::Dropdown, _scale, _layer, _location, _id), resource(_resource), entryResource(_entryResource), text(_text), textColour(_textColour),
-          originalTextColour(_textColour), textHoverColour(_hoverColour), textOffset(_textOffset), fontName(_fontName), entries(_entries) {
+          originalTextColour(_textColour), textHoverColour(_hoverColour), textOffset(_textOffset), fontName(_fontName), entries(_entries), isVisible(visible) {
             for(size_t i = 0; i < entries.size(); i++)
                 entryTextColour.push_back(textColour);
             if (text.empty() && entries.size() > 0)

--- a/src/UI/UIDropdown.h
+++ b/src/UI/UIDropdown.h
@@ -11,7 +11,7 @@ namespace OpenNFS {
       public:
         UIDropdown(UIResource const &_resource, UIResource const &_entryResource, std::string const &_text, glm::vec4 const &_textColour, glm::vec4 const &_textHoverColour,
                  float _scale, uint32_t _layer, glm::vec2 const &_location, glm::vec2 const &_textOffset, std::vector<std::string> _entries, std::string _id = "",
-                 std::string const &_fontName = "default");
+                 std::string const &_fontName = "default", bool const visible = true);
         void Update(glm::vec2 const &cursorPosition, bool click) override;
 
         void AddEntry(std::string entry);
@@ -30,5 +30,6 @@ namespace OpenNFS {
         std::vector<std::string> entries;
         std::vector<glm::vec4> entryTextColour;
         size_t selectedEntry = -1;
+        bool isVisible = true;
     };
 } // namespace OpenNFS

--- a/src/UI/UIDropdown.h
+++ b/src/UI/UIDropdown.h
@@ -16,7 +16,7 @@ namespace OpenNFS {
 
         void AddEntry(std::string entry);
 
-        size_t GetSelectedEntryIndex() {return selectedEntry;};
+        int GetSelectedEntryIndex() {return selectedEntry;};
 
         UIResource const &resource;
         UIResource const &entryResource;
@@ -29,7 +29,7 @@ namespace OpenNFS {
         bool isOpened = false;
         std::vector<std::string> entries;
         std::vector<glm::vec4> entryTextColour;
-        size_t selectedEntry = -1;
+        int selectedEntry = -1;
         bool isVisible = true;
     };
 } // namespace OpenNFS

--- a/src/UI/UILayoutLoader.cpp
+++ b/src/UI/UILayoutLoader.cpp
@@ -234,8 +234,9 @@ namespace OpenNFS {
                         if (elemJson.contains("entries") && elemJson["entries"].is_array()) {
                             dropdownElements = elemJson["entries"].get<std::vector<std::string>>();
                         }
+                        bool const visible = elemJson.value("visible", true);
                         element =
-                            std::make_unique<UIDropdown>(it->second, eit->second, text, colour, hoverColour, scale, layer, position, textOffset, dropdownElements, id, font);
+                            std::make_unique<UIDropdown>(it->second, eit->second, text, colour, hoverColour, scale, layer, position, textOffset, dropdownElements, id, font, visible);
                     } else {
                         LOG(WARNING) << "Unknown UI element type: " << type;
                         continue;


### PR DESCRIPTION
This adds a dropdown to the vehicle selection menu for selecting a colour for the car. For this it uses strings from the car menu data. Before selecting a car, the dropdown will be hidden. It will also not be visible when a car is selected that does not have colour options.

When you pick another car from the imgui menu in the race state, the colour will be set to be random again. Changing the track does not do this.